### PR TITLE
Add test2 image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,3 +62,10 @@ services:
       - 4202:80
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
+  oeb-nuxt-test2:
+    image: inab/openebench-nuxt-v3:test2
+    restart: always
+    ports:
+      - 4203:80
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,9 +63,9 @@ services:
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
   oeb-nuxt-test2:
-    image: inab/openebench-nuxt-v3:test2
+    image: ghcr.io/inab/openebench-nuxt-v3:test2
     restart: always
     ports:
       - 4203:80
     labels:
-      - "com.centurylinklabs.watchtower.enable=true"
+      - com.centurylinklabs.watchtower.enable: "true"


### PR DESCRIPTION
Update the file to create the "test2" image from the new test2 domain.
This is the image: [GITHUB image](https://github.com/inab/openEBench-nuxt-v3/pkgs/container/openebench-nuxt-v3/296875413?tag=test2)
In package documentation: docker pull ghcr.io/inab/openebench-nuxt-v3:test2

Not sure about that :(